### PR TITLE
feat(player): Compact mode for audio and video player

### DIFF
--- a/demo/src/App.vue
+++ b/demo/src/App.vue
@@ -13,6 +13,12 @@
         <audio-player :src="audioSrc" />
       </div>
 
+      <h3>Compact</h3>
+      <pre v-text="examples.audio.compact"/>
+      <div class="audio-container">
+        <audio-player compact :src="audioSrc" />
+      </div>
+
       <h3>Light mode</h3>
       <pre v-text="examples.audio.light"/>
       <div class="audio-container">
@@ -25,6 +31,16 @@
       <pre v-text="examples.video.basic"/>
       <div class="video-container">
         <video-player :src="videoSrc" />
+      </div>
+
+      <h3>Compact</h3>
+      <pre v-pre>
+        &lt;video-player compact&gt;
+          ...
+        &lt;/video-player&gt;
+      </pre>
+      <div class="video-container">
+        <video-player compact :src="videoSrc" />
       </div>
 
       <h3>Contained</h3>

--- a/demo/src/examples.js
+++ b/demo/src/examples.js
@@ -14,6 +14,20 @@ export default {
   }
 }
 </script>`,
+    compact: `<template>
+  <audio-player>
+    <source compact src="./example.mp3" />
+  </audio-player>
+</template>
+<script>
+import { audioPlayer } from 'vue-md-player'
+import 'vue-md-player/dist/vue-md-player.css'
+export default {
+  components: {
+    audioPlayer
+  }
+}
+</script>`,
     light: `<template>
   <audio-player src="./example.mp3" light />
 </template>`

--- a/src/assets/style.scss
+++ b/src/assets/style.scss
@@ -32,6 +32,17 @@
       opacity: 1;
     }
   }
+  &.compact {
+    min-height: 40px;
+    .control-bar {
+      height: 40px;
+      padding: 0;
+    }
+    .scrubber {
+      margin-top: -8px;
+      flex-grow: 1;
+    }
+  }
   .times {
     font-size: 13px;
     font-weight: 400;
@@ -42,6 +53,9 @@
     text-align: right;
     margin-right: 16px;
     padding: 10px 0;
+  }
+  &.compact .times {
+    flex-grow:0;
   }
   .layout {
     display: flex;

--- a/src/components/audio-player.vue
+++ b/src/components/audio-player.vue
@@ -10,6 +10,7 @@
     <!-- Control Bar-->
     <div class="control-bar visible">
       <scrubber
+          v-if="!compact"
         v-model="current"
         :min="0"
         :max="duration"
@@ -22,7 +23,15 @@
           <replay-icon v-else-if="ended"/>
           <play-icon v-else />
         </button>
-        <div class="spacer" />
+        <div v-if="!compact" class="spacer" />
+        <scrubber
+            v-if="compact"
+            v-model="current"
+            :min="0"
+            :max="duration"
+            @input="seek(current)"
+            :loading="isInProgress"
+        />
         <div class="flex times">
           <span v-text="currentTime"/>
           <span>&nbsp;/&nbsp;</span>
@@ -59,6 +68,10 @@ export default {
     light: {
       type: Boolean,
       default: false
+    },
+    compact: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -76,7 +89,8 @@ export default {
     classes () {
       return {
         'vuemdplayer audio': true,
-        'light': this.light
+        'light': this.light,
+        'compact': this.compact,
       }
     }
   }

--- a/src/components/video-player.vue
+++ b/src/components/video-player.vue
@@ -31,6 +31,7 @@
     <!-- Control Bar -->
     <div :class="{'control-bar': true, 'visible': controlbar || paused}" @click.stop>
       <scrubber
+        v-if="!compact"
         v-model="current"
         :min="0"
         :max="duration"
@@ -43,7 +44,15 @@
           <replay-icon v-else-if="ended"/>
           <play-icon v-else/>
         </button>
-        <div class="spacer" />
+        <div class="spacer" v-if="!compact" />
+        <scrubber
+            v-if="compact"
+            v-model="current"
+            :min="0"
+            :max="duration"
+            @input="seek(current)"
+            :loading="isInProgress"
+        />
         <div class="flex times">
           <span v-text="currentTime" />
           <span>&nbsp;/&nbsp;</span>
@@ -95,7 +104,11 @@ export default {
     contain: {
       type: Boolean,
       default: false
-    }
+    },
+    compact: {
+      type: Boolean,
+      default: false
+    },
   },
   components: {
     playIcon,
@@ -123,7 +136,8 @@ export default {
       return {
         'vuemdplayer video': true,
         'fullscreen': this.fullscreen,
-        'contain': this.fullscreen || this.contain
+        'contain': this.fullscreen || this.contain,
+        'compact': this.compact,
       }
     },
     styles () {


### PR DESCRIPTION
Enhancement to show the player in a more compact form using the compact flag.

This basically makes the player a single line, with Play/Pause, then time scrubber, then time on a single line.

Example:
![image](https://user-images.githubusercontent.com/1734519/204931487-d4c44c8a-2883-43f4-8550-12fbf1fffa6b.png)
